### PR TITLE
Fix searching subdirectories with spaces in them

### DIFF
--- a/makefile-runner.el
+++ b/makefile-runner.el
@@ -63,8 +63,8 @@
 ;;;###autoload
 
 (defcustom makefile-runner--makefiles
-  '(("Makefile"  makefile-runner--get-targets-make "cd %s; make %s")
-    ("build.xml" makefile-runner--get-targets-ant "cd %s; ant %s"))
+  '(("Makefile"  makefile-runner--get-targets-make "cd \"%s\"; make %s")
+    ("build.xml" makefile-runner--get-targets-ant "cd \"%s\"; ant %s"))
   "A list of (MAKEFILE-FILENAME FIND-TARGETS-PROCEDURE MAKEFILE-RUN-STRING)."
   :type 'sexp
   :group 'makefile-runner)


### PR DESCRIPTION
Running a makefile in a parent directory with a space in it would fail previously; this fixes it.
(ex. trying to run `~/My Programs/Foo/Makefile`, when editing the file `~/My Programs/Foo/src/kek.c`)